### PR TITLE
Auth work, KO integration, etc

### DIFF
--- a/apps/authentication/src/auth/auth.service.ts
+++ b/apps/authentication/src/auth/auth.service.ts
@@ -44,7 +44,12 @@ export class AuthService {
           this.httpService
             .post(
               process.env.LINK_TO_AUTHORIZATION_SERVICE,
-              { consentArtifact: caRes, gql: authDTO.gql }
+              {
+                consentArtifact: caRes,
+                requestType: authDTO.requestType,
+                gql: authDTO.gql,
+                queryObject: authDTO.queryObject
+              }
             )
             .pipe(map((response) => response.data)),
         );

--- a/apps/authentication/src/auth/dto/auth.dto.ts
+++ b/apps/authentication/src/auth/dto/auth.dto.ts
@@ -1,4 +1,6 @@
 export class AuthDto {
   caId: string
-  gql: string
+  requestType: string
+  gql?: string
+  queryObject?: JSON
 }

--- a/apps/consent-manager/src/types/consentArtifact.ts
+++ b/apps/consent-manager/src/types/consentArtifact.ts
@@ -15,7 +15,7 @@ export type ConsentArtifact = {
     frequency: Frequency
     total_queries_allowed: number
     log: Log
-    data: string
+    data: string | Array<string>
     proof: TheProofSchema
     [k: string]: unknown
 }

--- a/apps/gatekeeper/src/gql-utils/index.ts
+++ b/apps/gatekeeper/src/gql-utils/index.ts
@@ -2,17 +2,24 @@ import { parse, Entity } from './model';
 // import diff from 'microdiff';
 
 // KONNECT: Gatekeeper
-export const isSubset = (A: string, B: string): boolean => {
-  const astA = parse(A);
-  const astB = parse(B);
-  let subset = true;
-  astB.forEach((entity, name) => {
-    // console.log(name)
-    if (!isEntitySubset(astA.get(name), entity)) {
-      subset = false;
-    }
-  });
-  return subset;
+export const isSubset = (A: string, B: string | Array<string>): boolean => {
+  if (!B || !A) return false;
+
+  if (typeof B == 'string') {
+    const astA = parse(A);
+    const astB = parse(B);
+    let subset = true;
+    astB.forEach((entity, name) => {
+      // console.log(name)
+      if (!isEntitySubset(astA.get(name), entity)) {
+        subset = false;
+      }
+    });
+    return subset;
+  } else {
+    //@ts-ignore
+    return B.data.every(val => A.includes(val))
+  }
 };
 
 function isEntitySubset(A: Entity | undefined, B: Entity | undefined): boolean {

--- a/apps/gatekeeper/src/req-checker/req-checker.controller.ts
+++ b/apps/gatekeeper/src/req-checker/req-checker.controller.ts
@@ -8,8 +8,10 @@ export class ReqCheckerController {
   @Post()
   async reqChecker(@Body() body) {
     console.log('body: ', body);
-    console.log('gql:', body.gql);
     console.log('consentArtifact: ', body.consentArtifact);
-    return this.reqCheckerService.reqChecker(body.consentArtifact, body.gql);
+    console.log('requestType: ', body.requestType)
+    console.log('gql: ', body.gql)
+    console.log('queryObject: ', body.queryObject)
+    return this.reqCheckerService.reqChecker(body);
   }
 }

--- a/apps/gatekeeper/src/req-checker/req-checker.service.ts
+++ b/apps/gatekeeper/src/req-checker/req-checker.service.ts
@@ -8,36 +8,36 @@ import { ConsentArtifact } from './interface/req-checker.interface';
 export class ReqCheckerService {
   constructor(private readonly httpService: HttpService) { }
 
-  async reqChecker(consentArtifact: any, gqlQuery: string) {
-    console.log('consentArt: ', consentArtifact);
-    console.log('gqlQuery: ', gqlQuery);
-    if (!isSubset(consentArtifact.consent_artifact.data, gqlQuery)) {
+  async reqChecker(body: any) {
+    let consentArtifact = body.consentArtifact
+    let gqlQuery = body.gql
+    let requestType = body.requestType
+    let queryObject = body.queryObject
+
+    if (!isSubset(consentArtifact.consent_artifact.data, requestType == 'GQL' ? gqlQuery : queryObject)) {
       throw new ForbiddenException('Forbidden.');
     } else {
       // call the resolver here
-      const data = {
-        gql: gqlQuery,
-      };
 
       const requestOptions = {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: data,
+        body: body,
         redirect: 'follow',
       };
       try {
         const responseData = await lastValueFrom(
           this.httpService
-            .post(process.env.RESOLVER_URI, data, requestOptions)
+            .post(process.env.RESOLVER_URI, body, requestOptions)
             .pipe(
               map((response) => {
                 return response.data;
               }),
             ),
         );
-        console.log(responseData.data);
-        return responseData.data;
+        console.log(responseData);
+        return responseData;
       } catch (err) {
         console.log('error: ', err);
       }

--- a/apps/mock-ui/src/api/index.tsx
+++ b/apps/mock-ui/src/api/index.tsx
@@ -6,7 +6,7 @@ export const markFarmerChoice = async (url: string) => {
     {},
     {
       headers: {
-        authorization: localStorage.getItem("token"),
+        authorization: 'Bearer ' + localStorage.getItem("token"),
       },
     }
   );

--- a/apps/mock-ui/src/component/Notification/index.tsx
+++ b/apps/mock-ui/src/component/Notification/index.tsx
@@ -11,7 +11,7 @@ const NotificationItem: React.FC<Props> = (props) => {
   const notification = useNotification(data);
   console.log("notification", notification, data);
   const submitResponse = async (choice: string) => {
-    const url = `${data?.customAttributes?.collector?.url}/${data?.customAttributes?.id}/${choice}`;
+    const url = `${data?.customAttributes?.collector?.url}/auth/${data?.customAttributes?.id}/${choice}`;
     const res = await markFarmerChoice(url).catch((err) => {
       console.log(err);
     });

--- a/apps/resolver/src/req-resolver/req-resolver.controller.ts
+++ b/apps/resolver/src/req-resolver/req-resolver.controller.ts
@@ -8,7 +8,6 @@ export class ReqResolverController {
   @Post()
   resolveQuery(@Body() body) {
     console.log('body: ', body);
-    console.log('gql: ', body.gql);
-    return this.resolverService.resolveQuery(body.gql);
+    return this.resolverService.resolveQuery(body);
   }
 }

--- a/apps/resolver/src/req-resolver/req-resolver.service.ts
+++ b/apps/resolver/src/req-resolver/req-resolver.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { Body, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { lastValueFrom, map } from 'rxjs';
 
@@ -6,36 +6,95 @@ import { lastValueFrom, map } from 'rxjs';
 export class ReqResolverService {
   constructor(private readonly httpService: HttpService) { }
 
-  async resolveQuery(gqlQuery: JSON) {
-    if (!gqlQuery) return 'no query';
-    const graphql = JSON.stringify({
-      query: gqlQuery,
-      variables: {},
-    });
+  async resolveQuery(body: any) {
+    let farmerData = null
+    if (body.requestType == 'gql') {
 
-    const requestOptions = {
-      headers: {
-        'Content-Type': 'application/json',
-        'x-hasura-admin-secret': process.env.SECRET,
-      },
-      body: graphql,
-      redirect: 'follow',
-    };
+      if (!body.gql) return 'no query';
+      const graphql = JSON.stringify({
+        query: body.gql,
+        variables: {},
+      });
+      try {
 
-    try {
-      const responseData = await lastValueFrom(
-        this.httpService
-          .post(process.env.SERVER_URI, graphql, requestOptions)
-          .pipe(
-            map((response) => {
-              return response.data;
-            }),
-          ),
-      );
-      return responseData;
-    } catch (e) {
-      console.log('error: ', e);
-      throw new InternalServerErrorException();
+        // Extracting Aadhar Number from the query
+        let aadhar = body.gql.toString().split(")")[0]
+        aadhar = body.gql.toString().slice(aadhar.indexOf('aadhar'))
+        aadhar = aadhar.slice(aadhar.indexOf("\"") + 1, aadhar.indexOf("\"") + 13)
+
+        // Fetching farmer's data from KO
+        const requestOptions = {
+          headers: {
+            'Authorization': process.env.KO_AUTH_TOKEN,
+          }
+        };
+
+        console.log(`${process.env.KO_API_URL}/api/KrushakPortal/getFarmerDetails`, aadhar, requestOptions)
+
+        farmerData = await lastValueFrom(
+          this.httpService
+            .post(`${process.env.KO_API_URL}/api/KrushakPortal/getFarmerDetails`, { aadhaar_no: aadhar }, requestOptions)
+            .pipe(
+              map((response) => {
+                return response.data;
+              }),
+            ),
+        );
+
+      } catch (e) {
+        console.log('error: ', e);
+        throw new InternalServerErrorException();
+      }
+    } else {
+      // Perform REST operation
+      farmerData = await this.httpService.axiosRef.request({
+        method: body.queryObject.method,
+        url: `${process.env.KO_API_URL}/api/KrushakPortal/getFarmerDetails`,
+        headers: {
+          'Authorization': process.env.KO_AUTH_TOKEN,
+        },
+        data: body.queryObject.body
+      })
+      farmerData = farmerData.data;
+    }
+
+    let userHashMap = new Map();
+    console.log()
+    if (Object.keys(farmerData?.data)?.length > 0) {
+      Object.keys(farmerData?.data).forEach(key => {
+        if (Object.keys(farmerData.data[key]).length && (typeof farmerData.data[key] == 'object')) {
+          Object.keys(farmerData.data[key]).forEach(el => {
+            userHashMap[el] = farmerData.data[key][el];
+          })
+        }
+      })
+
+      // Creating response object
+      const responseObj = {};
+      console.log(userHashMap)
+
+      if (body.requestType == 'gql') {
+
+        // Extracting fields for the requested data
+        let fields = body.gql.toString().split(")")[1]
+        let items = fields.split("\n")
+        items = items.filter(el => !(el.includes("}") || el.includes("{"))).map(el => el.trim())
+
+        // Retrieving requested fields from user hash map
+        items.forEach(el => {
+          responseObj[el] = userHashMap[el]
+        })
+        console.log(responseObj)
+        return responseObj;
+      } else {
+        // Retrieving requested fields from user hash map for a REST requestType
+        body.queryObject.data.forEach(el => {
+          responseObj[el] = userHashMap[el]
+        })
+        return responseObj;
+      }
+    } else {
+      return null;
     }
   }
 }


### PR DESCRIPTION
# New Additions
Consent Manager is now generic and supports both `REST` and `GQL` operations. 
-It is now mandatory to provide a new parameter `requestType` which accepts two values for now, `REST or GQL`.

Sample Request Body For REST operation

```
{
    "caId": "6fdb3b47-58e1-46ae-85bb-9d546eb02693",
    "requestType": "REST",
    "queryObject": {
        "method": "POST",
        "headers": {},
        "body": {
             "aadhaar_no": "498279172952"
        },
        "data": ["intDay","intGender","intMaritalStatus","intMonth","intPrimaryMobileNumber"]
    }
}
```

### Significance of fields in`queryObject` 
`method` : The type of request method for the database/api
`headers`: Required headers for the request to be performed to fetch data
`body`: Required body for the request to be performed to fetch data. In this case aadhaar_no is the where clause intended
`data`: The information needed to from the entirety of data fetched.